### PR TITLE
Add Claude Code session initialization hooks

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install dependencies
+npm install
+
+# Start Vite dev server in background with host exposed for URL publishing
+npx vite --host 0.0.0.0 --port 5173 &

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds automatic session initialization configuration for Claude Code on the web, enabling the development environment to be set up automatically when a session starts.

## Key Changes
- Added `.claude/hooks/session-start.sh` - A bash script that runs on session start in remote Claude Code environments to:
  - Install npm dependencies via `npm install`
  - Start the Vite development server on `0.0.0.0:5173` to expose the URL for publishing
  
- Added `.claude/settings.json` - Configuration file that registers the session-start hook to execute automatically when Claude Code sessions begin in remote environments

## Implementation Details
- The hook script includes a guard clause to only execute in remote Claude Code environments (checks `CLAUDE_CODE_REMOTE` environment variable)
- The Vite server is started in the background with `--host 0.0.0.0` to allow external access and URL publishing capabilities
- Uses strict bash settings (`set -euo pipefail`) for reliable error handling

https://claude.ai/code/session_01YAVa8JtodBXnirFFihihSF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated development environment setup for Claude integration. The system now automatically installs project dependencies and starts the development server on port 5173 when sessions begin. This eliminates manual setup steps and enables developers to start working immediately without preliminary configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->